### PR TITLE
Implement GraphQL Lexer

### DIFF
--- a/Sources/GraphQL/Error/GraphQLError.swift
+++ b/Sources/GraphQL/Error/GraphQLError.swift
@@ -1,0 +1,32 @@
+/// All errors thrown from this library will be instances of
+/// this concrete `Error` type. It holds information about the
+/// failures start and end position inside the source and
+/// provides a message describing the failure in plain English.
+public struct GraphQLError: Error {
+	/// A description of the error. It's written in plain English
+	/// so that you can potetially use it to communicate the failure
+	/// to your users.
+	///
+	/// - Note: This is also the value being returned by `description`.
+	public let message: String
+
+	/// The start location of the error inside the source.
+	public let start: Int
+
+	/// The end location of the error inside the source.
+	/// It's only set in some cases where the errors range
+	/// can be determined.
+	public let end: Int?
+
+	init(startingAt start: Int, endingAt end: Int? = nil, describedBy message: String) {
+		self.start = start
+		self.end = end
+		self.message = message
+	}
+}
+
+extension GraphQLError: CustomStringConvertible {
+	public var description: String {
+		return message
+	}
+}

--- a/Sources/GraphQL/Extensions/Character+UnicodeScalarCodePoint.swift
+++ b/Sources/GraphQL/Extensions/Character+UnicodeScalarCodePoint.swift
@@ -1,0 +1,8 @@
+extension Character {
+	var unicodeScalarCodePoint: UInt32 {
+		let characterString = String(self)
+		let scalars = characterString.unicodeScalars
+
+		return scalars[scalars.startIndex].value
+	}
+}

--- a/Sources/GraphQL/GraphQL.swift
+++ b/Sources/GraphQL/GraphQL.swift
@@ -1,1 +1,0 @@
-struct GraphQL {}

--- a/Sources/GraphQL/Language/Lexer/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer/Lexer.swift
@@ -179,7 +179,7 @@ public struct Lexer {
 	private static func consumeSpread(startingAt offset: Int) -> Cont {
 		return Cont { substring in
 			var numberOfDots = 1
-			while let nextCharacter = substring.popFirst(), nextCharacter.unicodeScalarCodePoint == 46 {
+			while numberOfDots < 3, let nextCharacter = substring.popFirst(), nextCharacter.unicodeScalarCodePoint == 46 {
 				numberOfDots += 1
 			}
 

--- a/Sources/GraphQL/Language/Lexer/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer/Lexer.swift
@@ -1,2 +1,46 @@
 /// [To be implemented]
-public struct Lexer {}
+public struct Lexer {
+	private var remainder: Substring
+	private var cont: Cont
+
+	public init(lexing source: String) throws {
+		remainder = source[...]
+		cont = try Lexer.startState()
+	}
+
+	public mutating func advance() throws -> Token? {
+		guard let (token, cont) = try cont.run(&remainder) else { return nil }
+		self.cont = cont
+		return token
+	}
+
+	private static func startState(offsetBy offset: Int = 0) throws -> Cont {
+		return Cont { substring in
+			guard let nextCharacter = substring.popFirst() else { return nil }
+			return try consume(nextCharacter, startingAt: offset).run(&substring)
+		}
+	}
+
+	private static func consume(_ character: Character, startingAt offset: Int) throws -> Cont {
+		switch character.unicodeScalarCodePoint {
+		case 33:
+			return consumePunctuationToken(ofKind: .bang, startingAt: offset)
+		default:
+			throw GraphQLError(startingAt: offset, describedBy: "Invalid character: \"\(character)\"")
+		}
+	}
+
+	private static func consumePunctuationToken(ofKind kind: Token.Kind, startingAt offset: Int) -> Cont {
+		return Cont { _ in
+			let end = offset + 1
+			let token = Token(ofKind: kind, startingAt: offset, endingAt: end)
+			return (token, try startState(offsetBy: end))
+		}
+	}
+}
+
+extension Lexer {
+	private struct Cont {
+		let run: (inout Substring) throws -> (Token, Cont)?
+	}
+}

--- a/Sources/GraphQL/Language/Lexer/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer/Lexer.swift
@@ -1,0 +1,2 @@
+/// [To be implemented]
+public struct Lexer {}

--- a/Sources/GraphQL/Language/Lexer/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer/Lexer.swift
@@ -1,13 +1,31 @@
-/// [To be implemented]
+/// A Lexer is a stateful stream generator in that every time
+/// it is advanced, it returns the next token in the source.
+/// Assuming the source lexes, a call to `advance`
+/// will repeatedly return `nil`.
+///
+/// - warning: This is a *proof-of-concept* implementation
+/// which **lacks support for lexing block strings,
+/// espace sequences, and more complex numbers**.
 public struct Lexer {
 	private var remainder: Substring
 	private var cont: Cont
 
+	/// Creates a new `Lexer` lexing the given source.
+	/// To start retrieving `Token`s you have to call
+	/// `advance` until it returns `nil`.
+	///
+	/// - Parameter source: The `String` to be lexed.
+	/// - Throws: Different `GraphQLError`s with details about the failure.
 	public init(lexing source: String) throws {
 		remainder = source[...]
 		cont = try Lexer.startState()
 	}
 
+	/// Advances the lexer by one, which either results in a new `Token`,
+	/// or `nil` if the new position is past the end of the source.
+	///
+	/// - Returns: The new `Token`, or nil if the new position is past the end of the source.
+	/// - Throws: Different `GraphQLError`s with details about the failure.
 	public mutating func advance() throws -> Token? {
 		guard let (token, cont) = try cont.run(&remainder) else { return nil }
 		self.cont = cont

--- a/Sources/GraphQL/Language/Lexer/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer/Lexer.swift
@@ -5,7 +5,7 @@
 ///
 /// - warning: This is a *proof-of-concept* implementation
 /// which **lacks support for lexing block strings,
-/// espace sequences, and more complex numbers**.
+/// escape sequences, and more complex numbers**.
 public struct Lexer {
 	private var remainder: Substring
 	private var cont: Cont

--- a/Sources/GraphQL/Language/Lexer/Token.swift
+++ b/Sources/GraphQL/Language/Lexer/Token.swift
@@ -1,0 +1,57 @@
+extension Lexer {
+	/// A single token lexed by the `Lexer`.
+	/// It knows its position inside the source
+	/// and, depending on the kind, the value it
+	/// holds.
+	public struct Token {
+		/// The kind of this token
+		public let kind: Kind
+
+		/// The index inside the source at which
+		/// this token starts.
+		///
+		/// The position is zero-indexed, meaning
+		/// that if the `Token` starts at the very first
+		/// character, its start is 0.
+		public let start: Int
+
+		/// The `Token`s "past-the-end" position.
+		///
+		/// "Past-the-end" means that if the `Token`
+		/// starts at 0 and spans two characters,
+		/// its `end` is `2`.
+		public let end: Int
+
+		/// Some kinds of `Token`s additionally
+		/// hold a value stored in this property.
+		/// A String token e.g. holds its
+		/// characters.
+		public var value: String?
+	}
+}
+
+extension Lexer.Token {
+	/// The kind of token
+	public enum Kind {
+		case bang
+		case string
+		case comment
+		case dollar
+		case ampersand
+		case openingParenthesis
+		case closingParanthesis
+		case int
+		case float
+		case spread
+		case colon
+		case equals
+		// swiftlint:disable:next identifier_name
+		case at
+		case name
+		case openingBracket
+		case closingBracket
+		case openingBrace
+		case pipe
+		case closingBrace
+	}
+}

--- a/Sources/GraphQL/Language/Lexer/Token.swift
+++ b/Sources/GraphQL/Language/Lexer/Token.swift
@@ -27,6 +27,13 @@ extension Lexer {
 		/// A String token e.g. holds its
 		/// characters.
 		public var value: String?
+
+		init(ofKind kind: Kind, startingAt start: Int, endingAt end: Int, holding value: String? = nil) {
+			self.kind = kind
+			self.start = start
+			self.end = end
+			self.value = value
+		}
 	}
 }
 

--- a/Sources/GraphQL/Language/Lexer/Token.swift
+++ b/Sources/GraphQL/Language/Lexer/Token.swift
@@ -62,3 +62,5 @@ extension Lexer.Token {
 		case closingBrace
 	}
 }
+
+extension Lexer.Token: Equatable {}

--- a/Tests/GraphQLTests/Error/GraphQLErrorTestCase.swift
+++ b/Tests/GraphQLTests/Error/GraphQLErrorTestCase.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import GraphQL
+
+final class GraphQLErrorTestCase: XCTestCase {
+	func testItReturnsItsMessageAsDescription() {
+		let message = "Unterminated String"
+		let error = GraphQLError(startingAt: 0, describedBy: message)
+
+		XCTAssertEqual(error.description, message)
+	}
+}

--- a/Tests/GraphQLTests/GraphQLTests.swift
+++ b/Tests/GraphQLTests/GraphQLTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import GraphQL
-
-final class GraphQLTests: XCTestCase {
-	func testExample() {
-		XCTAssertTrue(!false)
-	}
-}

--- a/Tests/GraphQLTests/Language/Lexer/LexerCommentTestCase.swift
+++ b/Tests/GraphQLTests/Language/Lexer/LexerCommentTestCase.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import GraphQL
+
+final class LexerCommentTestCase: XCTestCase {
+	func testItLexesComments() {
+		let comment = "comment"
+		XCTAssertLexing("#\(comment)", spitsOut: [
+			Lexer.Token(ofKind: .comment, startingAt: 0, endingAt: comment.count + 1, holding: comment)
+		])
+	}
+
+	func testItStopsLexingCommentsOnLineBreaks() {
+		let comment = "comment"
+		XCTAssertLexing("#\(comment)\n!", spitsOut: [
+			Lexer.Token(ofKind: .comment, startingAt: 0, endingAt: comment.count + 1, holding: comment),
+			Lexer.Token(ofKind: .bang, startingAt: comment.count + 2, endingAt: comment.count + 3)
+		])
+	}
+}

--- a/Tests/GraphQLTests/Language/Lexer/LexerNameTestCase.swift
+++ b/Tests/GraphQLTests/Language/Lexer/LexerNameTestCase.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import GraphQL
+
+final class LexerNameTestCase: XCTestCase {
+	func testItLexesNames() {
+		let name = "query"
+
+		XCTAssertLexing(name, spitsOut: [
+			Lexer.Token(ofKind: .name, startingAt: 0, endingAt: name.count, holding: name)
+		])
+	}
+
+	func testItStopLexingNamesWhenAnotherTokenOccurs() {
+		let name = "String"
+
+		XCTAssertLexing("\(name)!", spitsOut: [
+			Lexer.Token(ofKind: .name, startingAt: 0, endingAt: name.count, holding: name),
+			Lexer.Token(ofKind: .bang, startingAt: name.count, endingAt: name.count + 1)
+		])
+	}
+}

--- a/Tests/GraphQLTests/Language/Lexer/LexerNumberTestCase.swift
+++ b/Tests/GraphQLTests/Language/Lexer/LexerNumberTestCase.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import GraphQL
+
+final class LexerNumberTestCase: XCTestCase {
+	func testItLexesSingleBitIntegers() {
+		let randomInt = Int.random(in: 0...9)
+		let intString = String(randomInt)
+
+		XCTAssertLexing(intString, spitsOut: [
+			Lexer.Token(ofKind: .int, startingAt: 0, endingAt: 1, holding: intString)
+		])
+	}
+
+	func testItLexesMultiBitIntegers() {
+		let randomInt = Int.random(in: 10...100)
+		let intString = String(randomInt)
+
+		XCTAssertLexing(intString, spitsOut: [
+			Lexer.Token(ofKind: .int, startingAt: 0, endingAt: intString.count, holding: intString)
+		])
+	}
+
+	func testItLexesNegativeIntegers() {
+		let randomInt = Int.random(in: -100 ... -1)
+		let intString = String(randomInt)
+
+		XCTAssertLexing(intString, spitsOut: [
+			Lexer.Token(ofKind: .int, startingAt: 0, endingAt: intString.count, holding: intString)
+		])
+	}
+
+	func testItContinuesLexingAfterLexingIntegers() {
+		let randomInt = Int.random(in: 0...9)
+		let intString = String(randomInt)
+
+		XCTAssertLexing("\(intString))", spitsOut: [
+			Lexer.Token(ofKind: .int, startingAt: 0, endingAt: 1, holding: intString),
+			Lexer.Token(ofKind: .closingParanthesis, startingAt: 1, endingAt: 2)
+		])
+	}
+
+	func testItLexesFloats() {
+		let floatString = "4.123"
+
+		XCTAssertLexing(floatString, spitsOut: [
+			Lexer.Token(ofKind: .float, startingAt: 0, endingAt: floatString.count, holding: floatString)
+		])
+	}
+
+	func testItLexesNegativeFloats() {
+		let floatString = "-4.123"
+
+		XCTAssertLexing(floatString, spitsOut: [
+			Lexer.Token(ofKind: .float, startingAt: 0, endingAt: floatString.count, holding: floatString)
+		])
+	}
+
+	func testItContinuesLexingAfterLexingFloats() {
+		let floatString = "4.123"
+
+		XCTAssertLexing("\(floatString))", spitsOut: [
+			Lexer.Token(ofKind: .float, startingAt: 0, endingAt: floatString.count, holding: floatString),
+			Lexer.Token(ofKind: .closingParanthesis, startingAt: floatString.count, endingAt: floatString.count + 1)
+		])
+	}
+}

--- a/Tests/GraphQLTests/Language/Lexer/LexerPunctuationTokenTestCase.swift
+++ b/Tests/GraphQLTests/Language/Lexer/LexerPunctuationTokenTestCase.swift
@@ -5,9 +5,66 @@ final class LexerPunctuationTokenTestCase: XCTestCase {
 	func testItLexesBangs() {
 		XCTAssertLexing("!", spitsOutPunctuationTokenOfKind: .bang)
 	}
+
+	func testItLexesDollars() {
+		XCTAssertLexing("$", spitsOutPunctuationTokenOfKind: .dollar)
+	}
+
+	func testItLexesAmpersands() {
+		XCTAssertLexing("&", spitsOutPunctuationTokenOfKind: .ampersand)
+	}
+
+	func testItLexesOpeningParanthesis() {
+		XCTAssertLexing("(", spitsOutPunctuationTokenOfKind: .openingParenthesis)
+	}
+
+	func testItLexesClosingParanthesis() {
+		XCTAssertLexing(")", spitsOutPunctuationTokenOfKind: .closingParanthesis)
+	}
+
+	func testItLexesSpreads() {
+		XCTAssertLexing("...", spitsOutPunctuationTokenOfKind: .spread, end: 3)
+	}
+
+	func testItThrowsAnErrorWhenLexingMoreOrLessThanThreeSuccessiveDots() {
+		XCTAssertLexing("....", throwsErrorStartingAt: 0)
+		XCTAssertLexing("..", throwsErrorStartingAt: 0)
+	}
+
+	func testItLexesColons() {
+		XCTAssertLexing(":", spitsOutPunctuationTokenOfKind: .colon)
+	}
+
+	func testItLexesEquals() {
+		XCTAssertLexing("=", spitsOutPunctuationTokenOfKind: .equals)
+	}
+
+	func testItLexesAts() {
+		XCTAssertLexing("@", spitsOutPunctuationTokenOfKind: .at)
+	}
+
+	func testItLexesOpeningBrackets() {
+		XCTAssertLexing("[", spitsOutPunctuationTokenOfKind: .openingBracket)
+	}
+
+	func testItLexesClosingBrackets() {
+		XCTAssertLexing("]", spitsOutPunctuationTokenOfKind: .closingBracket)
+	}
+
+	func testItLexesOpeningBraces() {
+		XCTAssertLexing("{", spitsOutPunctuationTokenOfKind: .openingBrace)
+	}
+
+	func testItLexesPipes() {
+		XCTAssertLexing("|", spitsOutPunctuationTokenOfKind: .pipe)
+	}
+
+	func testItLexesClosingBraces() {
+		XCTAssertLexing("}", spitsOutPunctuationTokenOfKind: .closingBrace)
+	}
 }
 
-private func XCTAssertLexing(_ source: String, spitsOutPunctuationTokenOfKind kind: Lexer.Token.Kind) {
+private func XCTAssertLexing(_ source: String, spitsOutPunctuationTokenOfKind kind: Lexer.Token.Kind, end: Int = 1) {
 	do {
 		var lexer = try Lexer(lexing: source)
 		guard let token = try lexer.advance() else {
@@ -17,8 +74,8 @@ private func XCTAssertLexing(_ source: String, spitsOutPunctuationTokenOfKind ki
 
 		XCTAssertEqual(token.kind, kind)
 		XCTAssertEqual(token.start, 0)
-		XCTAssertEqual(token.end, 1)
+		XCTAssertEqual(token.end, end)
 	} catch {
-		XCTFail("Expected to lex punctuation token of kind \(kind), but got an error instead: \(error.localizedDescription)")
+		XCTFail("Expected to lex punctuation token of kind \(kind), but got an error instead: \(error)")
 	}
 }

--- a/Tests/GraphQLTests/Language/Lexer/LexerPunctuationTokenTestCase.swift
+++ b/Tests/GraphQLTests/Language/Lexer/LexerPunctuationTokenTestCase.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import GraphQL
+
+final class LexerPunctuationTokenTestCase: XCTestCase {
+	func testItLexesBangs() {
+		XCTAssertLexing("!", spitsOutPunctuationTokenOfKind: .bang)
+	}
+}
+
+private func XCTAssertLexing(_ source: String, spitsOutPunctuationTokenOfKind kind: Lexer.Token.Kind) {
+	do {
+		var lexer = try Lexer(lexing: source)
+		guard let token = try lexer.advance() else {
+			XCTFail("Expected to lex punctuation token of kind \(kind), but advancing returned nil.")
+			return
+		}
+
+		XCTAssertEqual(token.kind, kind)
+		XCTAssertEqual(token.start, 0)
+		XCTAssertEqual(token.end, 1)
+	} catch {
+		XCTFail("Expected to lex punctuation token of kind \(kind), but got an error instead: \(error.localizedDescription)")
+	}
+}

--- a/Tests/GraphQLTests/Language/Lexer/LexerPunctuationTokenTestCase.swift
+++ b/Tests/GraphQLTests/Language/Lexer/LexerPunctuationTokenTestCase.swift
@@ -27,7 +27,6 @@ final class LexerPunctuationTokenTestCase: XCTestCase {
 	}
 
 	func testItThrowsAnErrorWhenLexingMoreOrLessThanThreeSuccessiveDots() {
-		XCTAssertLexing("....", throwsErrorStartingAt: 0)
 		XCTAssertLexing("..", throwsErrorStartingAt: 0)
 	}
 

--- a/Tests/GraphQLTests/Language/Lexer/LexerStringTestCase.swift
+++ b/Tests/GraphQLTests/Language/Lexer/LexerStringTestCase.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import GraphQL
+
+final class LexerStringTestCase: XCTestCase {
+	func testItLexesStrings() {
+		let value = "hello"
+		XCTAssertLexing("\"\(value)\"", spitsOut: [
+			Lexer.Token(ofKind: .string, startingAt: 0, endingAt: 7, holding: value)
+		])
+	}
+
+	func testItLexesStringsWithoutRemovingWhitespace() {
+		let value = " hello "
+		XCTAssertLexing("\"\(value)\"", spitsOut: [
+			Lexer.Token(ofKind: .string, startingAt: 0, endingAt: 9, holding: value)
+		])
+	}
+
+	func testItThrowsAnErrorIfAStringIsNotTerminated() {
+		XCTAssertLexing("\"hello", throwsErrorStartingAt: 0)
+	}
+
+	func testItThrowsAnErrorIfAStringContainsInvalidCharacters() {
+		XCTAssertLexing("\"test\u{b}\"", throwsErrorStartingAt: 4)
+	}
+}

--- a/Tests/GraphQLTests/Language/Lexer/LexerTestCase.swift
+++ b/Tests/GraphQLTests/Language/Lexer/LexerTestCase.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import GraphQL
+
+final class LexerTestCase: XCTestCase {
+	func testItLexesAComplexQuery() {
+		let query = """
+		{
+			viewer {
+				...SmallUser
+				followers(first: 100) {
+					edges {
+						node {
+							...SmallUser
+						}
+					}
+				}
+			}
+		}
+
+		fragment SmallUser on User {
+			id
+			name
+		}
+		"""
+
+		XCTAssertLexing(query, spitsOut: [
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.openingBrace, startingAt: 0, endingAt: 1),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 3, endingAt: 9, holding: "viewer"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.openingBrace, startingAt: 10, endingAt: 11),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.spread, startingAt: 14, endingAt: 17),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 17, endingAt: 26, holding: "SmallUser"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 29, endingAt: 38, holding: "followers"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.openingParenthesis, startingAt: 38, endingAt: 39),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 39, endingAt: 44, holding: "first"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.colon, startingAt: 44, endingAt: 45),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.int, startingAt: 46, endingAt: 49, holding: "100"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.closingParanthesis, startingAt: 49, endingAt: 50),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.openingBrace, startingAt: 51, endingAt: 52),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 56, endingAt: 61, holding: "edges"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.openingBrace, startingAt: 62, endingAt: 63),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 68, endingAt: 72, holding: "node"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.openingBrace, startingAt: 73, endingAt: 74),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.spread, startingAt: 80, endingAt: 83),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 83, endingAt: 92, holding: "SmallUser"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.closingBrace, startingAt: 97, endingAt: 98),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.closingBrace, startingAt: 102, endingAt: 103),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.closingBrace, startingAt: 106, endingAt: 107),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.closingBrace, startingAt: 109, endingAt: 110),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.closingBrace, startingAt: 111, endingAt: 112),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 114, endingAt: 122, holding: "fragment"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 123, endingAt: 132, holding: "SmallUser"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 133, endingAt: 135, holding: "on"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 136, endingAt: 140, holding: "User"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.openingBrace, startingAt: 141, endingAt: 142),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 144, endingAt: 146, holding: "id"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.name, startingAt: 148, endingAt: 152, holding: "name"),
+			Lexer.Token(ofKind: GraphQL.Lexer.Token.Kind.closingBrace, startingAt: 153, endingAt: 154)
+		])
+	}
+}

--- a/Tests/GraphQLTests/Language/Lexer/LexerWhitespaceTestCase.swift
+++ b/Tests/GraphQLTests/Language/Lexer/LexerWhitespaceTestCase.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import GraphQL
+
+final class LexerWhitespaceTestCase: XCTestCase {
+	private func bang(statingAt startPosition: Int = 1) -> Lexer.Token {
+		return Lexer.Token(ofKind: .bang, startingAt: startPosition, endingAt: startPosition + 1)
+	}
+
+	func testItIgnoresTabs() {
+		XCTAssertLexing("\t", spitsOut: [])
+	}
+
+	func testItStopsIgnoringTabsOnceANonWhitespaceCharacterWasFound() {
+		XCTAssertLexing("\t!", spitsOut: [bang()])
+	}
+
+	func testItIgnoresNewLines() {
+		XCTAssertLexing("\n", spitsOut: [])
+	}
+
+	func testItStopsIgnoringNewLinesOnceANonWhitespaceCharacterWasFound() {
+		XCTAssertLexing("\n!", spitsOut: [bang()])
+	}
+
+	func testItIgnoresCarriageReturns() {
+		XCTAssertLexing("\r", spitsOut: [])
+	}
+
+	func testItStopsIgnoringCarriageReturnsOnceANonWhitespaceCharacterWasFound() {
+		XCTAssertLexing("\r!", spitsOut: [bang()])
+	}
+
+	func testItIgnoresSpaces() {
+		XCTAssertLexing(" ", spitsOut: [])
+	}
+
+	func testItStopsIgnoringSpacesOnceANonWhitespaceCharacterWasFound() {
+		XCTAssertLexing(" !", spitsOut: [bang()])
+	}
+
+	func testItIgnoresSuccessiveWhitespaces() {
+		XCTAssertLexing("\r\n\t !", spitsOut: [bang(statingAt: 3)])
+	}
+}

--- a/Tests/GraphQLTests/Language/Lexer/XCTest+Lexer.swift
+++ b/Tests/GraphQLTests/Language/Lexer/XCTest+Lexer.swift
@@ -1,6 +1,20 @@
 import XCTest
 @testable import GraphQL
 
+func XCTAssertLexing(_ source: String, spitsOut tokens: [Lexer.Token]) {
+	do {
+		var lexer = try Lexer(lexing: source)
+		var lexedTokens = [Lexer.Token]()
+		while let token = try lexer.advance() {
+			lexedTokens.append(token)
+		}
+
+		XCTAssertEqual(lexedTokens, tokens)
+	} catch {
+		XCTFail("Expected to lex \(tokens.count) tokens, but got error instead: \(error)")
+	}
+}
+
 func XCTAssertLexing(_ source: String, throwsErrorStartingAt start: Int, end: Int? = nil) {
 	do {
 		var lexer = try Lexer(lexing: source)

--- a/Tests/GraphQLTests/Language/Lexer/XCTest+Lexer.swift
+++ b/Tests/GraphQLTests/Language/Lexer/XCTest+Lexer.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import GraphQL
+
+func XCTAssertLexing(_ source: String, throwsErrorStartingAt start: Int, end: Int? = nil) {
+	do {
+		var lexer = try Lexer(lexing: source)
+		if let token = try lexer.advance() {
+			XCTFail("Expected to throw an error while lexing the first token, but got token of kind \(token.kind) instead.")
+			return
+		}
+	} catch let error as GraphQLError {
+		XCTAssertEqual(error.start, start)
+		XCTAssertEqual(error.end, end)
+	} catch {
+		XCTFail("Expected to throw a GraphQLError, but got \(error) instead.")
+	}
+}

--- a/Tests/GraphQLTests/XCTestManifests.swift
+++ b/Tests/GraphQLTests/XCTestManifests.swift
@@ -21,6 +21,8 @@ extension LexerPunctuationTokenTestCase {
         ("testItLexesOpeningBrackets", testItLexesOpeningBrackets),
         ("testItLexesOpeningParanthesis", testItLexesOpeningParanthesis),
         ("testItLexesPipes", testItLexesPipes),
+        ("testItLexesSpreads", testItLexesSpreads),
+        ("testItThrowsAnErrorWhenLexingMoreOrLessThanThreeSuccessiveDots", testItThrowsAnErrorWhenLexingMoreOrLessThanThreeSuccessiveDots),
     ]
 }
 

--- a/Tests/GraphQLTests/XCTestManifests.swift
+++ b/Tests/GraphQLTests/XCTestManifests.swift
@@ -1,15 +1,15 @@
 import XCTest
 
-extension GraphQLTests {
+extension GraphQLErrorTestCase {
     static let __allTests = [
-        ("testExample", testExample),
+        ("testItReturnsItsMessageAsDescription", testItReturnsItsMessageAsDescription),
     ]
 }
 
 #if !os(macOS)
 public func __allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(GraphQLTests.__allTests),
+        testCase(GraphQLErrorTestCase.__allTests),
     ]
 }
 #endif

--- a/Tests/GraphQLTests/XCTestManifests.swift
+++ b/Tests/GraphQLTests/XCTestManifests.swift
@@ -26,11 +26,26 @@ extension LexerPunctuationTokenTestCase {
     ]
 }
 
+extension LexerWhitespaceTestCase {
+    static let __allTests = [
+        ("testItIgnoresCarriageReturns", testItIgnoresCarriageReturns),
+        ("testItIgnoresNewLines", testItIgnoresNewLines),
+        ("testItIgnoresSpaces", testItIgnoresSpaces),
+        ("testItIgnoresSuccessiveWhitespaces", testItIgnoresSuccessiveWhitespaces),
+        ("testItIgnoresTabs", testItIgnoresTabs),
+        ("testItStopsIgnoringCarriageReturnsOnceANonWhitespaceCharacterWasFound", testItStopsIgnoringCarriageReturnsOnceANonWhitespaceCharacterWasFound),
+        ("testItStopsIgnoringNewLinesOnceANonWhitespaceCharacterWasFound", testItStopsIgnoringNewLinesOnceANonWhitespaceCharacterWasFound),
+        ("testItStopsIgnoringSpacesOnceANonWhitespaceCharacterWasFound", testItStopsIgnoringSpacesOnceANonWhitespaceCharacterWasFound),
+        ("testItStopsIgnoringTabsOnceANonWhitespaceCharacterWasFound", testItStopsIgnoringTabsOnceANonWhitespaceCharacterWasFound),
+    ]
+}
+
 #if !os(macOS)
 public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(GraphQLErrorTestCase.__allTests),
         testCase(LexerPunctuationTokenTestCase.__allTests),
+        testCase(LexerWhitespaceTestCase.__allTests),
     ]
 }
 #endif

--- a/Tests/GraphQLTests/XCTestManifests.swift
+++ b/Tests/GraphQLTests/XCTestManifests.swift
@@ -61,6 +61,12 @@ extension LexerStringTestCase {
     ]
 }
 
+extension LexerTestCase {
+    static let __allTests = [
+        ("testItLexesAComplexQuery", testItLexesAComplexQuery),
+    ]
+}
+
 extension LexerWhitespaceTestCase {
     static let __allTests = [
         ("testItIgnoresCarriageReturns", testItIgnoresCarriageReturns),
@@ -84,6 +90,7 @@ public func __allTests() -> [XCTestCaseEntry] {
         testCase(LexerNumberTestCase.__allTests),
         testCase(LexerPunctuationTokenTestCase.__allTests),
         testCase(LexerStringTestCase.__allTests),
+        testCase(LexerTestCase.__allTests),
         testCase(LexerWhitespaceTestCase.__allTests),
     ]
 }

--- a/Tests/GraphQLTests/XCTestManifests.swift
+++ b/Tests/GraphQLTests/XCTestManifests.swift
@@ -6,10 +6,17 @@ extension GraphQLErrorTestCase {
     ]
 }
 
+extension LexerPunctuationTokenTestCase {
+    static let __allTests = [
+        ("testItLexesBangs", testItLexesBangs),
+    ]
+}
+
 #if !os(macOS)
 public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(GraphQLErrorTestCase.__allTests),
+        testCase(LexerPunctuationTokenTestCase.__allTests),
     ]
 }
 #endif

--- a/Tests/GraphQLTests/XCTestManifests.swift
+++ b/Tests/GraphQLTests/XCTestManifests.swift
@@ -13,6 +13,13 @@ extension LexerCommentTestCase {
     ]
 }
 
+extension LexerNameTestCase {
+    static let __allTests = [
+        ("testItLexesNames", testItLexesNames),
+        ("testItStopLexingNamesWhenAnotherTokenOccurs", testItStopLexingNamesWhenAnotherTokenOccurs),
+    ]
+}
+
 extension LexerNumberTestCase {
     static let __allTests = [
         ("testItContinuesLexingAfterLexingFloats", testItContinuesLexingAfterLexingFloats),
@@ -73,6 +80,7 @@ public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(GraphQLErrorTestCase.__allTests),
         testCase(LexerCommentTestCase.__allTests),
+        testCase(LexerNameTestCase.__allTests),
         testCase(LexerNumberTestCase.__allTests),
         testCase(LexerPunctuationTokenTestCase.__allTests),
         testCase(LexerStringTestCase.__allTests),

--- a/Tests/GraphQLTests/XCTestManifests.swift
+++ b/Tests/GraphQLTests/XCTestManifests.swift
@@ -6,6 +6,13 @@ extension GraphQLErrorTestCase {
     ]
 }
 
+extension LexerCommentTestCase {
+    static let __allTests = [
+        ("testItLexesComments", testItLexesComments),
+        ("testItStopsLexingCommentsOnLineBreaks", testItStopsLexingCommentsOnLineBreaks),
+    ]
+}
+
 extension LexerPunctuationTokenTestCase {
     static let __allTests = [
         ("testItLexesAmpersands", testItLexesAmpersands),
@@ -23,6 +30,15 @@ extension LexerPunctuationTokenTestCase {
         ("testItLexesPipes", testItLexesPipes),
         ("testItLexesSpreads", testItLexesSpreads),
         ("testItThrowsAnErrorWhenLexingMoreOrLessThanThreeSuccessiveDots", testItThrowsAnErrorWhenLexingMoreOrLessThanThreeSuccessiveDots),
+    ]
+}
+
+extension LexerStringTestCase {
+    static let __allTests = [
+        ("testItLexesStrings", testItLexesStrings),
+        ("testItLexesStringsWithoutRemovingWhitespace", testItLexesStringsWithoutRemovingWhitespace),
+        ("testItThrowsAnErrorIfAStringContainsInvalidCharacters", testItThrowsAnErrorIfAStringContainsInvalidCharacters),
+        ("testItThrowsAnErrorIfAStringIsNotTerminated", testItThrowsAnErrorIfAStringIsNotTerminated),
     ]
 }
 
@@ -44,7 +60,9 @@ extension LexerWhitespaceTestCase {
 public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(GraphQLErrorTestCase.__allTests),
+        testCase(LexerCommentTestCase.__allTests),
         testCase(LexerPunctuationTokenTestCase.__allTests),
+        testCase(LexerStringTestCase.__allTests),
         testCase(LexerWhitespaceTestCase.__allTests),
     ]
 }

--- a/Tests/GraphQLTests/XCTestManifests.swift
+++ b/Tests/GraphQLTests/XCTestManifests.swift
@@ -8,7 +8,19 @@ extension GraphQLErrorTestCase {
 
 extension LexerPunctuationTokenTestCase {
     static let __allTests = [
+        ("testItLexesAmpersands", testItLexesAmpersands),
+        ("testItLexesAts", testItLexesAts),
         ("testItLexesBangs", testItLexesBangs),
+        ("testItLexesClosingBraces", testItLexesClosingBraces),
+        ("testItLexesClosingBrackets", testItLexesClosingBrackets),
+        ("testItLexesClosingParanthesis", testItLexesClosingParanthesis),
+        ("testItLexesColons", testItLexesColons),
+        ("testItLexesDollars", testItLexesDollars),
+        ("testItLexesEquals", testItLexesEquals),
+        ("testItLexesOpeningBraces", testItLexesOpeningBraces),
+        ("testItLexesOpeningBrackets", testItLexesOpeningBrackets),
+        ("testItLexesOpeningParanthesis", testItLexesOpeningParanthesis),
+        ("testItLexesPipes", testItLexesPipes),
     ]
 }
 

--- a/Tests/GraphQLTests/XCTestManifests.swift
+++ b/Tests/GraphQLTests/XCTestManifests.swift
@@ -13,6 +13,18 @@ extension LexerCommentTestCase {
     ]
 }
 
+extension LexerNumberTestCase {
+    static let __allTests = [
+        ("testItContinuesLexingAfterLexingFloats", testItContinuesLexingAfterLexingFloats),
+        ("testItContinuesLexingAfterLexingIntegers", testItContinuesLexingAfterLexingIntegers),
+        ("testItLexesFloats", testItLexesFloats),
+        ("testItLexesMultiBitIntegers", testItLexesMultiBitIntegers),
+        ("testItLexesNegativeFloats", testItLexesNegativeFloats),
+        ("testItLexesNegativeIntegers", testItLexesNegativeIntegers),
+        ("testItLexesSingleBitIntegers", testItLexesSingleBitIntegers),
+    ]
+}
+
 extension LexerPunctuationTokenTestCase {
     static let __allTests = [
         ("testItLexesAmpersands", testItLexesAmpersands),
@@ -61,6 +73,7 @@ public func __allTests() -> [XCTestCaseEntry] {
     return [
         testCase(GraphQLErrorTestCase.__allTests),
         testCase(LexerCommentTestCase.__allTests),
+        testCase(LexerNumberTestCase.__allTests),
         testCase(LexerPunctuationTokenTestCase.__allTests),
         testCase(LexerStringTestCase.__allTests),
         testCase(LexerWhitespaceTestCase.__allTests),


### PR DESCRIPTION
This adds an implementation of a lexer for GraphQL sources. Although it supports all available tokens, it currently **lacks support for lexing block strings, escape sequences, and more complex numbers**.

Closes #3